### PR TITLE
Compare result fix

### DIFF
--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.kt
@@ -73,7 +73,7 @@ data class DeepLinkMatchResult(
      */
     override fun compareTo(other: DeepLinkMatchResult): Int {
         return when {
-            this.firstNonConcreteIndex < other.firstNonConcreteIndex -> 1
+            this.firstNonConcreteIndex < other.firstNonConcreteIndex -> -1
             this.firstNonConcreteIndex == other.firstNonConcreteIndex -> {
                 if (this.firstNonConcreteIndex == -1 || deeplinkEntry.uriTemplate[firstNonConcreteIndex] == other.deeplinkEntry.uriTemplate[firstNonConcreteIndex]) {
                     0
@@ -81,7 +81,7 @@ data class DeepLinkMatchResult(
                     -1
                 } else 1
             }
-            else -> -1
+            else -> 1
         }
     }
 }

--- a/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.kt
+++ b/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.kt
@@ -73,7 +73,7 @@ data class DeepLinkMatchResult(
      */
     override fun compareTo(other: DeepLinkMatchResult): Int {
         return when {
-            this.firstNonConcreteIndex < other.firstNonConcreteIndex -> -1
+            this.firstNonConcreteIndex < other.firstNonConcreteIndex -> 1
             this.firstNonConcreteIndex == other.firstNonConcreteIndex -> {
                 if (this.firstNonConcreteIndex == -1 || deeplinkEntry.uriTemplate[firstNonConcreteIndex] == other.deeplinkEntry.uriTemplate[firstNonConcreteIndex]) {
                     0
@@ -81,7 +81,7 @@ data class DeepLinkMatchResult(
                     -1
                 } else 1
             }
-            else -> 1
+            else -> -1
         }
     }
 }


### PR DESCRIPTION
In the lib description it was stated that module registration affects the conflict resolution order: If they are not defined in the same module the one defined in the registry listed first in DeeplinkDelegate will be matched.. In fact that’s not true. When conflict and duplicate was found [here](https://github.com/airbnb/DeepLinkDispatch/blob/5a14e69070c0df74a7c9393d14ea7cce35c09118/deeplinkdispatch/src/main/java/com/airbnb/deeplinkdispatch/BaseDeepLinkDelegate.kt#L559) then sorting is performed based on comparable [here](https://github.com/airbnb/DeepLinkDispatch/blob/5a14e69070c0df74a7c9393d14ea7cce35c09118/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.kt#L127).
The logic is broken because it is described that
```
// Found multiple matches. Sort matches by concreteness:
// No variable element > containing placeholders >  are a configurable path segment
```
But in fact we have the list sorted in the opposite way.
It looks like the logic [here](https://github.com/airbnb/DeepLinkDispatch/blob/5a14e69070c0df74a7c9393d14ea7cce35c09118/deeplinkdispatch-base/src/main/java/com/airbnb/deeplinkdispatch/DeepLinkEntry.kt#L129) sets the wrong value and -1 should be flipped to 1 to work as expected.